### PR TITLE
add kebab, pascal, snake

### DIFF
--- a/src/str.ts
+++ b/src/str.ts
@@ -190,6 +190,19 @@ export class Str {
   }
 
   /**
+   * Convert the string to kebab-case.
+   *
+   * @returns {Str}
+   */
+  kebab (): Str {
+    return new Str(
+      this.value.replace(/[_-\s]+/g, '-')
+    )
+      .strip()
+      .toLowerCase()
+  }
+
+  /**
    * Lowercases the first character in the string.
    *
    * @returns {Str}
@@ -253,6 +266,15 @@ export class Str {
   }
 
   /**
+   * Convert the string to PascalCase (same as StudlyCase). Alias for `.studly()`.
+   *
+   * @returns {Str}
+   */
+  pascal (): Str {
+    return this.studly()
+  }
+
+  /**
    * Create a random, URL-friendly string. The default length will have 21 symbols.
    *
    * @param {Number} [size=21] number of symbols in string
@@ -297,6 +319,19 @@ export class Str {
     return new Str(
       this.value.trimRight()
     )
+  }
+
+  /**
+   * Convert the string to snake_case.
+   *
+   * @returns {Str}
+   */
+  snake (): Str {
+    return new Str(
+      this.value.replace(/[_-\s]+/g, '_')
+    )
+      .strip()
+      .toLowerCase()
   }
 
   /**

--- a/test/str.js
+++ b/test/str.js
@@ -218,4 +218,27 @@ describe('Strings', () => {
     expect(Str('Supercharge').limit(11, ' ->').get()).to.equal('Supercharge')
     expect(Str('Supercharge').limit(12, ' ->').get()).to.equal('Supercharge')
   })
+  
+  it('kebab', () => {
+    expect(Str('super charge').kebab().get()).to.equal('super-charge')
+    expect(Str('supercharge is awesome').kebab().get()).to.equal('supercharge-is-awesome')
+    expect(Str('supercharge_IS_AWesoME').kebab().get()).to.equal('supercharge-is-awesome')
+    expect(Str('SUPERCHARGE_is_AWESOME').kebab().get()).to.equal('supercharge-is-awesome')
+    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').kebab().get()).to.equal('supercharge-is-awesome')
+  })
+
+  it('snake', () => {
+    expect(Str('super charge').snake().get()).to.equal('super_charge')
+    expect(Str('supercharge is awesome').snake().get()).to.equal('supercharge_is_awesome')
+    expect(Str('supercharge_IS_AWesoME').snake().get()).to.equal('supercharge_is_awesome')
+    expect(Str('SUPERCHARGE_is_AWESOME').snake().get()).to.equal('supercharge_is_awesome')
+    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').snake().get()).to.equal('supercharge_is_awesome')
+  })
+
+  it('pascal', () => {
+    expect(Str('supercharge is awesome').pascal().get()).to.equal('SuperchargeIsAwesome')
+    expect(Str('supercharge_IS_AWesoME').pascal().get()).to.equal('SuperchargeIsAwesome')
+    expect(Str('SUPERCHARGE_is_AWESOME').pascal().get()).to.equal('SuperchargeIsAwesome')
+    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').pascal().get()).to.equal('SuperchargeIsAwesome')
+  })
 })


### PR DESCRIPTION
Closes #21 

@marcuspoehls I found in documentation that `.studly()` converts to `StudlyCase`, which is equal to `PascalCase`. Thus I added alias `.pascal()`