### PR TITLE
Adds beforeLast and afterLast selectors

### DIFF
--- a/src/str.ts
+++ b/src/str.ts
@@ -72,6 +72,19 @@ export class Str {
   }
 
   /**
+   * Returns the portion of the string after the last occurrence of the given `delimiter`.
+   *
+   * @param {String} delimiter
+   *
+   * @return {Str}
+   */
+  afterLast (delimiter: string): Str {
+    return delimiter === ''
+      ? this
+      : new Str(this.split(delimiter).pop())
+  }
+
+  /**
    * Returns the portion of the string before the first occurrence of the given `delimiter`.
    *
    * @param {String} delimiter

--- a/src/str.ts
+++ b/src/str.ts
@@ -98,6 +98,25 @@ export class Str {
   }
 
   /**
+   * Returns the portion of the string before the last occurrence of the given `delimiter`.
+   *
+   * @param {String} delimiter
+   *
+   * @return {Str}
+   */
+  beforeLast (delimiter: string): Str {
+    if (delimiter === '') {
+      return this
+    }
+
+    const substrings = this.split(delimiter)
+
+    return substrings.length === 1
+      ? this // delimiter is not part of the string
+      : new Str(substrings.slice(0, -1).join(delimiter))
+  }
+
+  /**
    * Convert the string to camelCase.
    *
    * @returns {Str}

--- a/test/str.js
+++ b/test/str.js
@@ -20,6 +20,19 @@ describe('Strings', () => {
     expect(Str('super2charge').after(2).get()).toEqual('charge')
   })
 
+  it('afterLast', () => {
+    expect(Str('marcus').afterLast('c').get()).toEqual('us')
+    expect(Str('super-charge').afterLast('-').get()).toEqual('charge')
+    expect(Str('su-per-charge').afterLast('-').get()).toEqual('charge')
+
+    expect(Str('supercharge').afterLast('xxx').get()).toEqual('supercharge')
+    expect(Str('supercharge').afterLast('').get()).toEqual('supercharge')
+
+    expect(Str('super0charge').afterLast('0').get()).toEqual('charge')
+    expect(Str('super0charge').afterLast(0).get()).toEqual('charge')
+    expect(Str('super2charge').afterLast(2).get()).toEqual('charge')
+  })
+
   it('before', () => {
     expect(Str('marcus').before('cus').get()).toEqual('mar')
     expect(Str('super-charge').before('-').get()).toEqual('super')

--- a/test/str.js
+++ b/test/str.js
@@ -46,6 +46,19 @@ describe('Strings', () => {
     expect(Str('super2charge').before(2).get()).toEqual('super')
   })
 
+  it('beforeLast', () => {
+    expect(Str('marcus').beforeLast('cus').get()).toEqual('mar')
+    expect(Str('super-charge').beforeLast('-').get()).toEqual('super')
+    expect(Str('su-per-charge').beforeLast('-').get()).toEqual('su-per')
+
+    expect(Str('supercharge').beforeLast('xxx').get()).toEqual('supercharge')
+    expect(Str('supercharge').beforeLast('').get()).toEqual('supercharge')
+
+    expect(Str('super0charge').beforeLast('0').get()).toEqual('super')
+    expect(Str('super0charge').beforeLast(0).get()).toEqual('super')
+    expect(Str('super2charge').beforeLast(2).get()).toEqual('super')
+  })
+
   it('upper()', () => {
     expect(Str('supercharge').upper().get()).toEqual('SUPERCHARGE')
     expect(Str('SuperchargE').upper().get()).toEqual('SUPERCHARGE')


### PR DESCRIPTION
This PR adds support for the selectors `beforeLast(delimiter)` and `afterLast(delimiter)`.

As the work was mainly tweaking some things after copy-pasting already existing methods, feel free to request further changes (if you want to).

Closes #29 
Closes #30 