### PR TITLE
feat: add replace method

### DIFF
--- a/src/str.ts
+++ b/src/str.ts
@@ -1,13 +1,13 @@
-'use strict'
+"use strict";
 
-import Crypto from 'crypto'
-import { v4 as uuidv4 } from 'uuid'
+import Crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
 
 export class Str {
   /**
    * The string value to work with.
    */
-  private readonly value: string
+  private readonly value: string;
 
   /**
    * Create a new String instance providing chainable string operations.
@@ -18,8 +18,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  constructor (value?: any) {
-    this.value = String(value || '').slice(0)
+  constructor(value?: any) {
+    this.value = String(value || "").slice(0);
   }
 
   /**
@@ -30,8 +30,8 @@ export class Str {
    *
    * @returns {String}
    */
-  static get alphabet (): string {
-    return 'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW'
+  static get alphabet(): string {
+    return "ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW";
   }
 
   /**
@@ -39,8 +39,8 @@ export class Str {
    *
    * @returns {String}
    */
-  get (): string {
-    return this.toString()
+  get(): string {
+    return this.toString();
   }
 
   /**
@@ -48,8 +48,8 @@ export class Str {
    *
    * @returns {String}
    */
-  toString (): string {
-    return this.value
+  toString(): string {
+    return this.value;
   }
 
   /**
@@ -59,16 +59,16 @@ export class Str {
    *
    * @returns {Str}
    */
-  after (delimiter: string): Str {
-    if (delimiter === '') {
-      return this
+  after(delimiter: string): Str {
+    if (delimiter === "") {
+      return this;
     }
 
-    const substrings = this.split(delimiter)
+    const substrings = this.split(delimiter);
 
     return substrings.length === 1
       ? this // delimiter is not part of the string
-      : new Str(substrings.slice(1).join(delimiter))
+      : new Str(substrings.slice(1).join(delimiter));
   }
 
   /**
@@ -78,10 +78,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  before (delimiter: string): Str {
-    return delimiter === ''
-      ? this
-      : new Str(this.split(delimiter).shift())
+  before(delimiter: string): Str {
+    return delimiter === "" ? this : new Str(this.split(delimiter).shift());
   }
 
   /**
@@ -89,8 +87,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  camel (): Str {
-    return this.studly().lcFirst()
+  camel(): Str {
+    return this.studly().lcFirst();
   }
 
   /**
@@ -100,12 +98,10 @@ export class Str {
    *
    * @returns {Str}
    */
-  concat (...strings: string[]): Str {
-    strings = ([] as string[]).concat(...strings)
+  concat(...strings: string[]): Str {
+    strings = ([] as string[]).concat(...strings);
 
-    return new Str(
-      this.value.concat(...strings)
-    )
+    return new Str(this.value.concat(...strings));
   }
 
   /**
@@ -115,8 +111,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  contains (needle: string): boolean {
-    return this.includes(needle)
+  contains(needle: string): boolean {
+    return this.includes(needle);
   }
 
   /**
@@ -126,14 +122,14 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  containsAll (needles: string[]): boolean {
+  containsAll(needles: string[]): boolean {
     for (const needle of ([] as string[]).concat(needles)) {
       if (this.notContains(needle)) {
-        return false
+        return false;
       }
     }
 
-    return true
+    return true;
   }
 
   /**
@@ -143,8 +139,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  notContains (needle: string): boolean {
-    return !this.contains(needle)
+  notContains(needle: string): boolean {
+    return !this.contains(needle);
   }
 
   /**
@@ -156,8 +152,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  endsWith (needle: string, length?: number): boolean {
-    return this.value.endsWith(needle, length)
+  endsWith(needle: string, length?: number): boolean {
+    return this.value.endsWith(needle, length);
   }
 
   /**
@@ -167,8 +163,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  equals (value: string): boolean {
-    return this.value === value
+  equals(value: string): boolean {
+    return this.value === value;
   }
 
   /**
@@ -178,10 +174,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  includes (needle: any): boolean {
-    return new Str(needle).isEmpty()
-      ? false
-      : this.value.includes(needle)
+  includes(needle: any): boolean {
+    return new Str(needle).isEmpty() ? false : this.value.includes(needle);
   }
 
   /**
@@ -189,8 +183,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isEmpty (): boolean {
-    return this.value.length === 0
+  isEmpty(): boolean {
+    return this.value.length === 0;
   }
 
   /**
@@ -198,8 +192,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isLower (): boolean {
-    return this.isLowercase()
+  isLower(): boolean {
+    return this.isLowercase();
   }
 
   /**
@@ -207,8 +201,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isLowercase (): boolean {
-    return this.value === this.lower().get()
+  isLowercase(): boolean {
+    return this.value === this.lower().get();
   }
 
   /**
@@ -216,8 +210,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isNotEmpty (): boolean {
-    return !this.isEmpty()
+  isNotEmpty(): boolean {
+    return !this.isEmpty();
   }
 
   /**
@@ -227,8 +221,11 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isString (input: any): boolean {
-    return typeof input === 'string' && Object.prototype.toString.call(input) === '[object String]'
+  isString(input: any): boolean {
+    return (
+      typeof input === "string" &&
+      Object.prototype.toString.call(input) === "[object String]"
+    );
   }
 
   /**
@@ -236,8 +233,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isUpper (): boolean {
-    return this.isUppercase()
+  isUpper(): boolean {
+    return this.isUppercase();
   }
 
   /**
@@ -245,8 +242,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  isUppercase (): boolean {
-    return this.value === this.upper().get()
+  isUppercase(): boolean {
+    return this.value === this.upper().get();
   }
 
   /**
@@ -254,12 +251,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  kebab (): Str {
-    return new Str(
-      this.value.replace(/[_-\s]+/g, '-')
-    )
-      .strip()
-      .toLowerCase()
+  kebab(): Str {
+    return new Str(this.value.replace(/[_-\s]+/g, "-")).strip().toLowerCase();
   }
 
   /**
@@ -267,10 +260,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  lcFirst (): Str {
-    return new Str(
-      this.value[0].toLowerCase() + this.value.slice(1)
-    )
+  lcFirst(): Str {
+    return new Str(this.value[0].toLowerCase() + this.value.slice(1));
   }
 
   /**
@@ -278,8 +269,8 @@ export class Str {
    *
    * @returns {Number}
    */
-  length (): number {
-    return this.value.length
+  length(): number {
+    return this.value.length;
   }
 
   /**
@@ -290,10 +281,10 @@ export class Str {
    *
    * @returns {Str}
    */
-  limit (limit: number = 0, end: string = ''): Str {
+  limit(limit: number = 0, end: string = ""): Str {
     return limit >= this.length()
       ? this
-      : new Str(this.value.substring(0, limit).concat(end))
+      : new Str(this.value.substring(0, limit).concat(end));
   }
 
   /**
@@ -301,8 +292,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  lower (): Str {
-    return this.toLowerCase()
+  lower(): Str {
+    return this.toLowerCase();
   }
 
   /**
@@ -310,8 +301,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  lowercase (): Str {
-    return this.toLowerCase()
+  lowercase(): Str {
+    return this.toLowerCase();
   }
 
   /**
@@ -323,20 +314,16 @@ export class Str {
    *
    * @returns {Str}
    */
-  ltrim (characters: string = ''): Str {
+  ltrim(characters: string = ""): Str {
     if (!characters) {
-      return new Str(
-        this.value.trimLeft()
-      )
+      return new Str(this.value.trimLeft());
     }
 
     if (this.value.startsWith(characters)) {
-      return new Str(
-        this.value.substring(characters.length)
-      )
+      return new Str(this.value.substring(characters.length));
     }
 
-    return new Str(this.value)
+    return new Str(this.value);
   }
 
   /**
@@ -344,8 +331,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  pascal (): Str {
-    return this.studly()
+  pascal(): Str {
+    return this.studly();
   }
 
   /**
@@ -355,17 +342,17 @@ export class Str {
    *
    * @returns {String}
    */
-  random (size = 21): string {
-    const bytes = Crypto.randomBytes(size)
-    const alphabetLength = Str.alphabet.length - 1
+  random(size = 21): string {
+    const bytes = Crypto.randomBytes(size);
+    const alphabetLength = Str.alphabet.length - 1;
 
-    let random = ''
+    let random = "";
 
     while (size--) {
-      random += Str.alphabet[bytes[size] & alphabetLength]
+      random += Str.alphabet[bytes[size] & alphabetLength];
     }
 
-    return random
+    return random;
   }
 
   /**
@@ -376,12 +363,21 @@ export class Str {
    *
    * @returns {Str}
    */
-  replaceAll (search: string|RegExp, replace: string): Str {
-    const replacer = new RegExp(search, 'g')
+  replaceAll(search: string | RegExp, replace: string): Str {
+    const replacer = new RegExp(search, "g");
 
-    return new Str(
-      this.value.replace(replacer, replace)
-    )
+    return new Str(this.value.replace(replacer, replace));
+  }
+
+  /**
+   * Replace the first occurence of `search` with `replace` in a string.
+   * @param {*} search
+   * @param {*} replace
+   *
+   * @returns {Str}
+   */
+  replace(search: string | RegExp, replace: string): Str {
+    return new Str(this.value.replace(search, replace));
   }
 
   /**
@@ -393,20 +389,21 @@ export class Str {
    *
    * @returns {Str}
    */
-  rtrim (characters: string = ''): Str {
+  rtrim(characters: string = ""): Str {
     if (!characters) {
-      return new Str(
-        this.value.trimRight()
-      )
+      return new Str(this.value.trimRight());
     }
 
     if (this.value.endsWith(characters)) {
       return new Str(
-        this.value.substring(-characters.length, this.value.length - characters.length)
-      )
+        this.value.substring(
+          -characters.length,
+          this.value.length - characters.length
+        )
+      );
     }
 
-    return new Str(this.value)
+    return new Str(this.value);
   }
 
   /**
@@ -414,12 +411,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  snake (): Str {
-    return new Str(
-      this.value.replace(/[_-\s]+/g, '_')
-    )
-      .strip()
-      .toLowerCase()
+  snake(): Str {
+    return new Str(this.value.replace(/[_-\s]+/g, "_")).strip().toLowerCase();
   }
 
   /**
@@ -431,8 +424,8 @@ export class Str {
    *
    * @returns {Array}
    */
-  split (separator: string, limit?: number): string[] {
-    return this.value.split(separator, limit)
+  split(separator: string, limit?: number): string[] {
+    return this.value.split(separator, limit);
   }
 
   /**
@@ -445,8 +438,8 @@ export class Str {
    *
    * @returns {Boolean}
    */
-  startsWith (needle: string, position?: number): boolean {
-    return this.value.startsWith(needle, position)
+  startsWith(needle: string, position?: number): boolean {
+    return this.value.startsWith(needle, position);
   }
 
   /**
@@ -454,10 +447,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  strip (): Str {
-    return new Str(
-      this.value.replace(/\s+/g, '')
-    )
+  strip(): Str {
+    return new Str(this.value.replace(/\s+/g, ""));
   }
 
   /**
@@ -465,8 +456,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  stripNums (): Str {
-    return this.replaceAll(/\d+/, '')
+  stripNums(): Str {
+    return this.replaceAll(/\d+/, "");
   }
 
   /**
@@ -475,12 +466,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  studly (): Str {
-    return new Str(
-      this.value.replace(/[_-]+/g, ' ')
-    )
-      .title()
-      .strip()
+  studly(): Str {
+    return new Str(this.value.replace(/[_-]+/g, " ")).title().strip();
   }
 
   /**
@@ -491,10 +478,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  substr (start: number, length: number): Str {
-    return new Str(
-      this.value.substring(start, length)
-    )
+  substr(start: number, length: number): Str {
+    return new Str(this.value.substring(start, length));
   }
 
   /**
@@ -502,15 +487,14 @@ export class Str {
    *
    * @returns {Str}
    */
-  title (): Str {
+  title(): Str {
     return new Str(
-      this
-        .lowercase()
-        .split(' ')
-        .filter(s => s)
-        .map(s => s[0].toUpperCase() + s.slice(1))
-        .join(' ')
-    )
+      this.lowercase()
+        .split(" ")
+        .filter((s) => s)
+        .map((s) => s[0].toUpperCase() + s.slice(1))
+        .join(" ")
+    );
   }
 
   /**
@@ -519,10 +503,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  toLowerCase (): Str {
-    return new Str(
-      this.value.toLowerCase()
-    )
+  toLowerCase(): Str {
+    return new Str(this.value.toLowerCase());
   }
 
   /**
@@ -531,10 +513,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  toUpperCase (): Str {
-    return new Str(
-      this.value.toUpperCase()
-    )
+  toUpperCase(): Str {
+    return new Str(this.value.toUpperCase());
   }
 
   /**
@@ -546,10 +526,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  trim (characters: string = ''): Str {
-    return this
-      .ltrim(characters)
-      .rtrim(characters)
+  trim(characters: string = ""): Str {
+    return this.ltrim(characters).rtrim(characters);
   }
 
   /**
@@ -557,10 +535,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  ucFirst (): Str {
-    return new Str(
-      this.value[0].toUpperCase() + this.value.slice(1)
-    )
+  ucFirst(): Str {
+    return new Str(this.value[0].toUpperCase() + this.value.slice(1));
   }
 
   /**
@@ -568,8 +544,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  upper (): Str {
-    return this.toUpperCase()
+  upper(): Str {
+    return this.toUpperCase();
   }
 
   /**
@@ -577,8 +553,8 @@ export class Str {
    *
    * @returns {Str}
    */
-  uppercase (): Str {
-    return this.toUpperCase()
+  uppercase(): Str {
+    return this.toUpperCase();
   }
 
   /**
@@ -586,7 +562,7 @@ export class Str {
    *
    * @returns {String}
    */
-  uuid (): string {
-    return uuidv4()
+  uuid(): string {
+    return uuidv4();
   }
 }

--- a/test/str.js
+++ b/test/str.js
@@ -1,307 +1,403 @@
-'use strict'
+"use strict";
 
-const Str = require('../dist')
+const Str = require("../dist");
 
-describe('Strings', () => {
-  it('get', () => {
-    expect(Str('supercharge').get()).toEqual('supercharge')
-  })
+describe("Strings", () => {
+  it("get", () => {
+    expect(Str("supercharge").get()).toEqual("supercharge");
+  });
 
-  it('after', () => {
-    expect(Str('marcus').after('mar').get()).toEqual('cus')
-    expect(Str('super-charge').after('-').get()).toEqual('charge')
-    expect(Str('su-per-charge').after('-').get()).toEqual('per-charge')
+  it("after", () => {
+    expect(Str("marcus").after("mar").get()).toEqual("cus");
+    expect(Str("super-charge").after("-").get()).toEqual("charge");
+    expect(Str("su-per-charge").after("-").get()).toEqual("per-charge");
 
-    expect(Str('supercharge').after('xxx').get()).toEqual('supercharge')
-    expect(Str('supercharge').after('').get()).toEqual('supercharge')
+    expect(Str("supercharge").after("xxx").get()).toEqual("supercharge");
+    expect(Str("supercharge").after("").get()).toEqual("supercharge");
 
-    expect(Str('super0charge').after('0').get()).toEqual('charge')
-    expect(Str('super0charge').after(0).get()).toEqual('charge')
-    expect(Str('super2charge').after(2).get()).toEqual('charge')
-  })
+    expect(Str("super0charge").after("0").get()).toEqual("charge");
+    expect(Str("super0charge").after(0).get()).toEqual("charge");
+    expect(Str("super2charge").after(2).get()).toEqual("charge");
+  });
 
-  it('before', () => {
-    expect(Str('marcus').before('cus').get()).toEqual('mar')
-    expect(Str('super-charge').before('-').get()).toEqual('super')
-    expect(Str('su-per-charge').before('-').get()).toEqual('su')
+  it("before", () => {
+    expect(Str("marcus").before("cus").get()).toEqual("mar");
+    expect(Str("super-charge").before("-").get()).toEqual("super");
+    expect(Str("su-per-charge").before("-").get()).toEqual("su");
 
-    expect(Str('supercharge').before('xxx').get()).toEqual('supercharge')
-    expect(Str('supercharge').before('').get()).toEqual('supercharge')
+    expect(Str("supercharge").before("xxx").get()).toEqual("supercharge");
+    expect(Str("supercharge").before("").get()).toEqual("supercharge");
 
-    expect(Str('super0charge').before('0').get()).toEqual('super')
-    expect(Str('super0charge').before(0).get()).toEqual('super')
-    expect(Str('super2charge').before(2).get()).toEqual('super')
-  })
+    expect(Str("super0charge").before("0").get()).toEqual("super");
+    expect(Str("super0charge").before(0).get()).toEqual("super");
+    expect(Str("super2charge").before(2).get()).toEqual("super");
+  });
 
-  it('upper()', () => {
-    expect(Str('supercharge').upper().get()).toEqual('SUPERCHARGE')
-    expect(Str('SuperchargE').upper().get()).toEqual('SUPERCHARGE')
-  })
+  it("upper()", () => {
+    expect(Str("supercharge").upper().get()).toEqual("SUPERCHARGE");
+    expect(Str("SuperchargE").upper().get()).toEqual("SUPERCHARGE");
+  });
 
-  it('uppercase()', () => {
-    expect(Str('supercharge').uppercase().get()).toEqual('SUPERCHARGE')
-    expect(Str('SuperchargE').uppercase().get()).toEqual('SUPERCHARGE')
-  })
+  it("uppercase()", () => {
+    expect(Str("supercharge").uppercase().get()).toEqual("SUPERCHARGE");
+    expect(Str("SuperchargE").uppercase().get()).toEqual("SUPERCHARGE");
+  });
 
-  it('isUpper()', () => {
-    expect(Str('SUPERCHARGE').isUpper()).toBe(true)
-    expect(Str('sUPERCHARGE').isUpper()).toBe(false)
-    expect(Str('superchargE').isUpper()).toBe(false)
-  })
+  it("isUpper()", () => {
+    expect(Str("SUPERCHARGE").isUpper()).toBe(true);
+    expect(Str("sUPERCHARGE").isUpper()).toBe(false);
+    expect(Str("superchargE").isUpper()).toBe(false);
+  });
 
-  it('ucFirst()', () => {
-    expect(Str('supercharge').ucFirst().get()).toEqual('Supercharge')
-    expect(Str('sUPERCHARGE').ucFirst().get()).toEqual('SUPERCHARGE')
-    expect(Str('sUPERCHARGE     IS AWESOME').ucFirst().get()).toEqual('SUPERCHARGE     IS AWESOME')
-  })
+  it("ucFirst()", () => {
+    expect(Str("supercharge").ucFirst().get()).toEqual("Supercharge");
+    expect(Str("sUPERCHARGE").ucFirst().get()).toEqual("SUPERCHARGE");
+    expect(Str("sUPERCHARGE     IS AWESOME").ucFirst().get()).toEqual(
+      "SUPERCHARGE     IS AWESOME"
+    );
+  });
 
-  it('lower()', () => {
-    expect(Str('SUPERCHARGE').lower().get()).toEqual('supercharge')
-    expect(Str('SuperchargE').lower().get()).toEqual('supercharge')
-  })
+  it("lower()", () => {
+    expect(Str("SUPERCHARGE").lower().get()).toEqual("supercharge");
+    expect(Str("SuperchargE").lower().get()).toEqual("supercharge");
+  });
 
-  it('lowercase()', () => {
-    expect(Str('SUPERCHARGE').lowercase().get()).toEqual('supercharge')
-    expect(Str('SuperchargE').lowercase().get()).toEqual('supercharge')
-  })
+  it("lowercase()", () => {
+    expect(Str("SUPERCHARGE").lowercase().get()).toEqual("supercharge");
+    expect(Str("SuperchargE").lowercase().get()).toEqual("supercharge");
+  });
 
-  it('isLower()', () => {
-    expect(Str('supercharge').isLower()).toBe(true)
-    expect(Str('sUPERCHARGE').isLower()).toBe(false)
-    expect(Str('SUPERCHARGE').isLower()).toBe(false)
-  })
+  it("isLower()", () => {
+    expect(Str("supercharge").isLower()).toBe(true);
+    expect(Str("sUPERCHARGE").isLower()).toBe(false);
+    expect(Str("SUPERCHARGE").isLower()).toBe(false);
+  });
 
-  it('lcFirst()', () => {
-    expect(Str('Supercharge').lcFirst().get()).toEqual('supercharge')
-    expect(Str('SUPERCHARGE').lcFirst().get()).toEqual('sUPERCHARGE')
-    expect(Str('SUPERCHARGE     IS AWESOME').lcFirst().get()).toEqual('sUPERCHARGE     IS AWESOME')
-  })
+  it("lcFirst()", () => {
+    expect(Str("Supercharge").lcFirst().get()).toEqual("supercharge");
+    expect(Str("SUPERCHARGE").lcFirst().get()).toEqual("sUPERCHARGE");
+    expect(Str("SUPERCHARGE     IS AWESOME").lcFirst().get()).toEqual(
+      "sUPERCHARGE     IS AWESOME"
+    );
+  });
 
-  it('strip', () => {
-    expect(Str('supercharge is awesome').strip().get()).toEqual('superchargeisawesome')
-    expect(Str('    supercharge IS aWesoME').strip().get()).toEqual('superchargeISaWesoME')
-    expect(Str('SUPERCHARGE     IS AWESOME   ').strip().get()).toEqual('SUPERCHARGEISAWESOME')
-  })
+  it("strip", () => {
+    expect(Str("supercharge is awesome").strip().get()).toEqual(
+      "superchargeisawesome"
+    );
+    expect(Str("    supercharge IS aWesoME").strip().get()).toEqual(
+      "superchargeISaWesoME"
+    );
+    expect(Str("SUPERCHARGE     IS AWESOME   ").strip().get()).toEqual(
+      "SUPERCHARGEISAWESOME"
+    );
+  });
 
-  it('stripNums', () => {
-    expect(Str('supercharge 123 is awesome').stripNums().get()).toEqual('supercharge  is awesome')
-    expect(Str('5up3rch4rge 12 awes0me 6789').stripNums().get()).toEqual('uprchrge  awesme ')
-  })
+  it("stripNums", () => {
+    expect(Str("supercharge 123 is awesome").stripNums().get()).toEqual(
+      "supercharge  is awesome"
+    );
+    expect(Str("5up3rch4rge 12 awes0me 6789").stripNums().get()).toEqual(
+      "uprchrge  awesme "
+    );
+  });
 
-  it('title()', () => {
-    expect(Str('supercharge is awesome').title().get()).toEqual('Supercharge Is Awesome')
-    expect(Str('supercharge IS AWesoME').title().get()).toEqual('Supercharge Is Awesome')
-    expect(Str('SUPERCHARGE IS AWESOME').title().get()).toEqual('Supercharge Is Awesome')
-  })
+  it("title()", () => {
+    expect(Str("supercharge is awesome").title().get()).toEqual(
+      "Supercharge Is Awesome"
+    );
+    expect(Str("supercharge IS AWesoME").title().get()).toEqual(
+      "Supercharge Is Awesome"
+    );
+    expect(Str("SUPERCHARGE IS AWESOME").title().get()).toEqual(
+      "Supercharge Is Awesome"
+    );
+  });
 
-  it('camel()', () => {
-    expect(Str('supercharge is awesome').camel().get()).toEqual('superchargeIsAwesome')
-    expect(Str('supercharge_IS_AWesoME').camel().get()).toEqual('superchargeIsAwesome')
-    expect(Str('SUPERCHARGE_is_AWESOME').camel().get()).toEqual('superchargeIsAwesome')
-    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').camel().get()).toEqual('superchargeIsAwesome')
-  })
+  it("camel()", () => {
+    expect(Str("supercharge is awesome").camel().get()).toEqual(
+      "superchargeIsAwesome"
+    );
+    expect(Str("supercharge_IS_AWesoME").camel().get()).toEqual(
+      "superchargeIsAwesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME").camel().get()).toEqual(
+      "superchargeIsAwesome"
+    );
+    expect(
+      Str("SUPERCHARGE  -_- is -_-  -_-     AWESOME").camel().get()
+    ).toEqual("superchargeIsAwesome");
+  });
 
-  it('studly()', () => {
-    expect(Str('supercharge is awesome').studly().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('supercharge_IS_AWesoME').studly().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('SUPERCHARGE_is_AWESOME').studly().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').studly().get()).toEqual('SuperchargeIsAwesome')
-  })
+  it("studly()", () => {
+    expect(Str("supercharge is awesome").studly().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(Str("supercharge_IS_AWesoME").studly().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME").studly().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(
+      Str("SUPERCHARGE  -_- is -_-  -_-     AWESOME").studly().get()
+    ).toEqual("SuperchargeIsAwesome");
+  });
 
-  it('trim()', () => {
-    expect(Str('  supercharge').trim().get()).toEqual('supercharge')
-    expect(Str(' supercharge ').trim().get()).toEqual('supercharge')
-    expect(Str('sUPERCHARGE  ').trim().get()).toEqual('sUPERCHARGE')
-    expect(Str('/supercharge/').trim('/').get()).toEqual('supercharge')
-    expect(Str('/supercharge/').trim('abc').get()).toEqual('/supercharge/')
-  })
+  it("trim()", () => {
+    expect(Str("  supercharge").trim().get()).toEqual("supercharge");
+    expect(Str(" supercharge ").trim().get()).toEqual("supercharge");
+    expect(Str("sUPERCHARGE  ").trim().get()).toEqual("sUPERCHARGE");
+    expect(Str("/supercharge/").trim("/").get()).toEqual("supercharge");
+    expect(Str("/supercharge/").trim("abc").get()).toEqual("/supercharge/");
+  });
 
-  it('contains()', () => {
-    expect(Str('supercharge').contains('arge')).toBe(true)
-    expect(Str('supercharge').contains('supercharge')).toBe(true)
+  it("contains()", () => {
+    expect(Str("supercharge").contains("arge")).toBe(true);
+    expect(Str("supercharge").contains("supercharge")).toBe(true);
 
-    expect(Str('supercharge').contains('abc')).toBe(false)
-    expect(Str('supercharge').contains('')).toBe(false)
-  })
+    expect(Str("supercharge").contains("abc")).toBe(false);
+    expect(Str("supercharge").contains("")).toBe(false);
+  });
 
-  it('containsAll', () => {
-    expect(Str('supercharge is awesome').containsAll('supercharge')).toBe(true)
-    expect(Str('supercharge is awesome').containsAll(['supercharge'])).toBe(true)
-    expect(Str('supercharge is awesome').containsAll(['is', 'awesome'])).toBe(true)
+  it("containsAll", () => {
+    expect(Str("supercharge is awesome").containsAll("supercharge")).toBe(true);
+    expect(Str("supercharge is awesome").containsAll(["supercharge"])).toBe(
+      true
+    );
+    expect(Str("supercharge is awesome").containsAll(["is", "awesome"])).toBe(
+      true
+    );
 
-    expect(Str('supercharge is awesome').containsAll(['supercharge', 'bad'])).toBe(false)
-  })
+    expect(
+      Str("supercharge is awesome").containsAll(["supercharge", "bad"])
+    ).toBe(false);
+  });
 
-  it('notContains()', () => {
-    expect(Str('supercharge').notContains('')).toBe(true)
-    expect(Str('supercharge').notContains('sub')).toBe(true)
-    expect(Str('supercharge').notContains('charger')).toBe(true)
+  it("notContains()", () => {
+    expect(Str("supercharge").notContains("")).toBe(true);
+    expect(Str("supercharge").notContains("sub")).toBe(true);
+    expect(Str("supercharge").notContains("charger")).toBe(true);
 
-    expect(Str('supercharge').notContains('super')).toBe(false)
-  })
+    expect(Str("supercharge").notContains("super")).toBe(false);
+  });
 
-  it('length()', () => {
-    expect(Str('supercharge').length()).toEqual(11)
-    expect(Str(' 123').length()).toEqual(4)
-    expect(Str('').length()).toEqual(0)
-  })
+  it("length()", () => {
+    expect(Str("supercharge").length()).toEqual(11);
+    expect(Str(" 123").length()).toEqual(4);
+    expect(Str("").length()).toEqual(0);
+  });
 
-  it('isEmpty()', () => {
-    expect(Str().isEmpty()).toBe(true)
-    expect(Str('').isEmpty()).toBe(true)
-    expect(Str(null).isEmpty()).toBe(true)
-    expect(Str('Supercharge').isEmpty()).toBe(false)
-  })
+  it("isEmpty()", () => {
+    expect(Str().isEmpty()).toBe(true);
+    expect(Str("").isEmpty()).toBe(true);
+    expect(Str(null).isEmpty()).toBe(true);
+    expect(Str("Supercharge").isEmpty()).toBe(false);
+  });
 
-  it('isNotEmpty()', () => {
-    expect(Str().isNotEmpty()).toBe(false)
-    expect(Str('').isNotEmpty()).toBe(false)
-    expect(Str(null).isNotEmpty()).toBe(false)
-    expect(Str('Supercharge').isNotEmpty()).toBe(true)
-  })
+  it("isNotEmpty()", () => {
+    expect(Str().isNotEmpty()).toBe(false);
+    expect(Str("").isNotEmpty()).toBe(false);
+    expect(Str(null).isNotEmpty()).toBe(false);
+    expect(Str("Supercharge").isNotEmpty()).toBe(true);
+  });
 
-  it('uuid()', () => {
-    expect(Str.uuid).toBeInstanceOf(Function)
-    expect(Str.uuid().split('-').length).toEqual(5)
-  })
+  it("uuid()", () => {
+    expect(Str.uuid).toBeInstanceOf(Function);
+    expect(Str.uuid().split("-").length).toEqual(5);
+  });
 
-  it('split()', () => {
-    expect(Str('Supercharge-is-awesome').split('-')).toEqual(['Supercharge', 'is', 'awesome'])
-    expect(Str('Supercharge-is-awesome').split()).toEqual(['Supercharge-is-awesome'])
-    expect(Str('Supercharge').split('-')).toEqual(['Supercharge'])
-  })
+  it("split()", () => {
+    expect(Str("Supercharge-is-awesome").split("-")).toEqual([
+      "Supercharge",
+      "is",
+      "awesome",
+    ]);
+    expect(Str("Supercharge-is-awesome").split()).toEqual([
+      "Supercharge-is-awesome",
+    ]);
+    expect(Str("Supercharge").split("-")).toEqual(["Supercharge"]);
+  });
 
-  it('random()', () => {
-    expect(Str.random())
+  it("random()", () => {
+    expect(Str.random());
 
     // default length is 21 chars
-    expect(Str.random().length).toEqual(21)
+    expect(Str.random().length).toEqual(21);
 
     // supports a custom length
-    expect(Str.random(50))
-    expect(Str.random(50).length).toEqual(50)
-  })
+    expect(Str.random(50));
+    expect(Str.random(50).length).toEqual(50);
+  });
 
-  it('replaceAll', () => {
+  it("replaceAll", () => {
     expect(
-      Str('Supercharge Is Super Awesome').replaceAll(' ', '-').get()
-    ).toEqual('Supercharge-Is-Super-Awesome')
+      Str("Supercharge Is Super Awesome").replaceAll(" ", "-").get()
+    ).toEqual("Supercharge-Is-Super-Awesome");
+
+    expect(Str("Supercharge is awesome").replaceAll("-", "/").get()).toEqual(
+      "Supercharge is awesome"
+    );
 
     expect(
-      Str('Supercharge is awesome').replaceAll('-', '/').get()
-    ).toEqual('Supercharge is awesome')
+      Str("Supercharge is awesome").title().replaceAll(" ", "-").camel().get()
+    ).toEqual("superchargeIsAwesome");
+  });
+
+  it("replace", () => {
+    expect(Str("Supercharge is nice").replace("nice", "sweet").get()).toEqual(
+      "Supercharge is sweet"
+    );
 
     expect(
-      Str('Supercharge is awesome')
-        .title()
-        .replaceAll(' ', '-')
-        .camel()
-        .get()
-    ).toEqual('superchargeIsAwesome')
-  })
+      Str("Supercharge is nice").replace("nice", "sweet").camel().get()
+    ).toEqual("superchargeIsSweet");
+  });
 
-  it('equals', () => {
-    expect(Str('Supercharge').equals('Supercharge')).toBe(true)
+  it("equals", () => {
+    expect(Str("Supercharge").equals("Supercharge")).toBe(true);
 
-    expect(Str('Super').equals('super')).toBe(false)
-    expect(Str('Super').equals()).toBe(false)
-  })
+    expect(Str("Super").equals("super")).toBe(false);
+    expect(Str("Super").equals()).toBe(false);
+  });
 
-  it('startsWith', () => {
-    expect(Str('Supercharge').startsWith('Super')).toBe(true)
-    expect(Str('Supercharge').startsWith('charge', 5)).toBe(true)
+  it("startsWith", () => {
+    expect(Str("Supercharge").startsWith("Super")).toBe(true);
+    expect(Str("Supercharge").startsWith("charge", 5)).toBe(true);
 
-    expect(Str('Supercharge').startsWith('super')).toBe(false)
-    expect(Str('Super').startsWith('Super', 10)).toBe(false)
-    expect(Str('Super').startsWith()).toBe(false)
-  })
+    expect(Str("Supercharge").startsWith("super")).toBe(false);
+    expect(Str("Super").startsWith("Super", 10)).toBe(false);
+    expect(Str("Super").startsWith()).toBe(false);
+  });
 
-  it('endsWith', () => {
-    expect(Str('Supercharge').endsWith('charge')).toBe(true)
-    expect(Str('Supercharge').endsWith('Chare')).toBe(false)
+  it("endsWith", () => {
+    expect(Str("Supercharge").endsWith("charge")).toBe(true);
+    expect(Str("Supercharge").endsWith("Chare")).toBe(false);
 
-    expect(Str('abc').endsWith('abc', 3)).toBe(true)
-    expect(Str('abc').endsWith('abc', 4)).toBe(true)
-    expect(Str('Supercharge').endsWith('charge', 5)).toBe(false)
-    expect(Str('Super').endsWith()).toBe(false)
-  })
+    expect(Str("abc").endsWith("abc", 3)).toBe(true);
+    expect(Str("abc").endsWith("abc", 4)).toBe(true);
+    expect(Str("Supercharge").endsWith("charge", 5)).toBe(false);
+    expect(Str("Super").endsWith()).toBe(false);
+  });
 
-  it('ltrim', () => {
-    expect(Str('   Supercharge').ltrim().get()).toEqual('Supercharge')
-    expect(Str('   Supercharge').ltrim(null).get()).toEqual('Supercharge')
-    expect(Str('   Supercharge').ltrim('').get()).toEqual('Supercharge')
-    expect(Str('Supercharge').ltrim('abc').get()).toEqual('Supercharge')
-    expect(Str('/supercharge/').ltrim('/').get()).toEqual('supercharge/')
-    expect(Str('   Supercharge').ltrim('Supercharge').get()).toEqual('   Supercharge')
-    expect(Str('   supercharge   ').ltrim('Supercharge').get()).toEqual('   supercharge   ')
-  })
+  it("ltrim", () => {
+    expect(Str("   Supercharge").ltrim().get()).toEqual("Supercharge");
+    expect(Str("   Supercharge").ltrim(null).get()).toEqual("Supercharge");
+    expect(Str("   Supercharge").ltrim("").get()).toEqual("Supercharge");
+    expect(Str("Supercharge").ltrim("abc").get()).toEqual("Supercharge");
+    expect(Str("/supercharge/").ltrim("/").get()).toEqual("supercharge/");
+    expect(Str("   Supercharge").ltrim("Supercharge").get()).toEqual(
+      "   Supercharge"
+    );
+    expect(Str("   supercharge   ").ltrim("Supercharge").get()).toEqual(
+      "   supercharge   "
+    );
+  });
 
-  it('rtrim', () => {
-    expect(Str('Supercharge   ').rtrim().get()).toEqual('Supercharge')
-    expect(Str('Supercharge   ').rtrim(null).get()).toEqual('Supercharge')
-    expect(Str('Supercharge   ').rtrim('').get()).toEqual('Supercharge')
-    expect(Str('Supercharge').rtrim('abc').get()).toEqual('Supercharge')
-    expect(Str('/supercharge/').rtrim('/').get()).toEqual('/supercharge')
-    expect(Str('Supercharge   ').rtrim('Supercharge').get()).toEqual('Supercharge   ')
-  })
+  it("rtrim", () => {
+    expect(Str("Supercharge   ").rtrim().get()).toEqual("Supercharge");
+    expect(Str("Supercharge   ").rtrim(null).get()).toEqual("Supercharge");
+    expect(Str("Supercharge   ").rtrim("").get()).toEqual("Supercharge");
+    expect(Str("Supercharge").rtrim("abc").get()).toEqual("Supercharge");
+    expect(Str("/supercharge/").rtrim("/").get()).toEqual("/supercharge");
+    expect(Str("Supercharge   ").rtrim("Supercharge").get()).toEqual(
+      "Supercharge   "
+    );
+  });
 
-  it('concat', () => {
-    expect(Str('Supercharge').concat('-is', '-great').get()).toEqual('Supercharge-is-great')
-    expect(Str('Supercharge').concat([' is', ' great']).get()).toEqual('Supercharge is great')
-  })
+  it("concat", () => {
+    expect(Str("Supercharge").concat("-is", "-great").get()).toEqual(
+      "Supercharge-is-great"
+    );
+    expect(Str("Supercharge").concat([" is", " great"]).get()).toEqual(
+      "Supercharge is great"
+    );
+  });
 
-  it('isString', () => {
-    expect(Str.isString('')).toBe(true)
-    expect(Str.isString(String())).toBe(true)
-    expect(Str.isString('Supercharge')).toBe(true)
+  it("isString", () => {
+    expect(Str.isString("")).toBe(true);
+    expect(Str.isString(String())).toBe(true);
+    expect(Str.isString("Supercharge")).toBe(true);
 
-    expect(Str.isString(1)).toBe(false)
-    expect(Str.isString({})).toBe(false)
-  })
+    expect(Str.isString(1)).toBe(false);
+    expect(Str.isString({})).toBe(false);
+  });
 
-  it('limit', () => {
-    expect(Str('Supercharge').limit(5, ' ->').get()).toEqual('Super ->')
-    expect(Str('Supercharge').limit(5).get()).toEqual('Super')
+  it("limit", () => {
+    expect(Str("Supercharge").limit(5, " ->").get()).toEqual("Super ->");
+    expect(Str("Supercharge").limit(5).get()).toEqual("Super");
 
-    expect(Str('Supercharge').limit().get()).toEqual('')
-    expect(Str('Supercharge').limit(0).get()).toEqual('')
-    expect(Str('Supercharge').limit(0, ' ->').get()).toEqual(' ->')
+    expect(Str("Supercharge").limit().get()).toEqual("");
+    expect(Str("Supercharge").limit(0).get()).toEqual("");
+    expect(Str("Supercharge").limit(0, " ->").get()).toEqual(" ->");
 
-    expect(Str('Supercharge').limit(11, ' ->').get()).toEqual('Supercharge')
-    expect(Str('Supercharge').limit(12, ' ->').get()).toEqual('Supercharge')
-  })
+    expect(Str("Supercharge").limit(11, " ->").get()).toEqual("Supercharge");
+    expect(Str("Supercharge").limit(12, " ->").get()).toEqual("Supercharge");
+  });
 
-  it('kebab', () => {
-    expect(Str('super charge').kebab().get()).toEqual('super-charge')
-    expect(Str('supercharge is awesome').kebab().get()).toEqual('supercharge-is-awesome')
-    expect(Str('supercharge_IS_AWesoME').kebab().get()).toEqual('supercharge-is-awesome')
-    expect(Str('SUPERCHARGE_is_AWESOME').kebab().get()).toEqual('supercharge-is-awesome')
-    expect(Str('supercharge_IS_AWesoME!').kebab().get()).toEqual('supercharge-is-awesome!')
-    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').kebab().get()).toEqual('supercharge-is-awesome')
-  })
+  it("kebab", () => {
+    expect(Str("super charge").kebab().get()).toEqual("super-charge");
+    expect(Str("supercharge is awesome").kebab().get()).toEqual(
+      "supercharge-is-awesome"
+    );
+    expect(Str("supercharge_IS_AWesoME").kebab().get()).toEqual(
+      "supercharge-is-awesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME").kebab().get()).toEqual(
+      "supercharge-is-awesome"
+    );
+    expect(Str("supercharge_IS_AWesoME!").kebab().get()).toEqual(
+      "supercharge-is-awesome!"
+    );
+    expect(
+      Str("SUPERCHARGE  -_- is -_-  -_-     AWESOME").kebab().get()
+    ).toEqual("supercharge-is-awesome");
+  });
 
-  it('snake', () => {
-    expect(Str('super charge').snake().get()).toEqual('super_charge')
-    expect(Str('supercharge is awesome').snake().get()).toEqual('supercharge_is_awesome')
-    expect(Str('supercharge_IS_AWesoME').snake().get()).toEqual('supercharge_is_awesome')
-    expect(Str('SUPERCHARGE_is_AWESOME').snake().get()).toEqual('supercharge_is_awesome')
-    expect(Str('SUPERCHARGE_is_AWESOME!').snake().get()).toEqual('supercharge_is_awesome!')
-    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').snake().get()).toEqual('supercharge_is_awesome')
-  })
+  it("snake", () => {
+    expect(Str("super charge").snake().get()).toEqual("super_charge");
+    expect(Str("supercharge is awesome").snake().get()).toEqual(
+      "supercharge_is_awesome"
+    );
+    expect(Str("supercharge_IS_AWesoME").snake().get()).toEqual(
+      "supercharge_is_awesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME").snake().get()).toEqual(
+      "supercharge_is_awesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME!").snake().get()).toEqual(
+      "supercharge_is_awesome!"
+    );
+    expect(
+      Str("SUPERCHARGE  -_- is -_-  -_-     AWESOME").snake().get()
+    ).toEqual("supercharge_is_awesome");
+  });
 
-  it('pascal', () => {
-    expect(Str('supercharge is awesome').pascal().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('supercharge_IS_AWesoME').pascal().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('SUPERCHARGE_is_AWESOME').pascal().get()).toEqual('SuperchargeIsAwesome')
-    expect(Str('SUPERCHARGE_is_AWESOME!').pascal().get()).toEqual('SuperchargeIsAwesome!')
-    expect(Str('SUPERCHARGE  -_- is -_-  -_-     AWESOME').pascal().get()).toEqual('SuperchargeIsAwesome')
-  })
+  it("pascal", () => {
+    expect(Str("supercharge is awesome").pascal().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(Str("supercharge_IS_AWesoME").pascal().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME").pascal().get()).toEqual(
+      "SuperchargeIsAwesome"
+    );
+    expect(Str("SUPERCHARGE_is_AWESOME!").pascal().get()).toEqual(
+      "SuperchargeIsAwesome!"
+    );
+    expect(
+      Str("SUPERCHARGE  -_- is -_-  -_-     AWESOME").pascal().get()
+    ).toEqual("SuperchargeIsAwesome");
+  });
 
-  it('substr', () => {
-    expect(Str('Supercharge').substr(0, 5).get()).toEqual('Super')
-    expect(Str('Supercharge').substr(5, 0).get()).toEqual('Super')
-    expect(Str('Supercharge').substr(5).get()).toEqual('charge')
-    expect(Str('Supercharge').substr().get()).toEqual('Supercharge')
-    expect(Str('Supercharge is awesome').substr(0, 11).get()).toEqual('Supercharge')
-  })
-})
+  it("substr", () => {
+    expect(Str("Supercharge").substr(0, 5).get()).toEqual("Super");
+    expect(Str("Supercharge").substr(5, 0).get()).toEqual("Super");
+    expect(Str("Supercharge").substr(5).get()).toEqual("charge");
+    expect(Str("Supercharge").substr().get()).toEqual("Supercharge");
+    expect(Str("Supercharge is awesome").substr(0, 11).get()).toEqual(
+      "Supercharge"
+    );
+  });
+});


### PR DESCRIPTION
Issue: [#31](https://github.com/supercharge/strings/issues/31)

Add a new `.replace(search, replace)` method that replaces the first occurrence of the given `search` value with the replacing `value`.

Example
```js
Str('Supercharge is nice').replace('nice', 'sweet').get()

// 'Supercharge is sweet'
```

**Note**: @marcuspoehls, please save both files once in your IDE as it changed coding style in my VS-Code IDE. e.g:- `" "` instead of `' '` and added extra `semi-columns`