### PR TITLE
Method isSymbol

### DIFF
--- a/src/str.ts
+++ b/src/str.ts
@@ -361,7 +361,7 @@ export class Str {
    * @returns {Boolean}
    */
   isSymbol (input: any): input is symbol {
-    // TODO
+    return typeof input === 'symbol' || (typeof input === 'object' && Object.prototype.toString.call(input) === '[object Symbol]')
   }
 
   /**

--- a/test/str.js
+++ b/test/str.js
@@ -534,6 +534,7 @@ describe('Strings', () => {
   it('isSymbol', () => {
     expect(Str.isSymbol(Symbol.for(''))).toBe(true)
     expect(Str.isSymbol(Symbol.for('Supercharge'))).toBe(true)
+    expect(Str.isSymbol(Object(Symbol.for('Supercharge')))).toBe(true)
 
     expect(Str.isSymbol(Symbol)).toBe(false)
     expect(Str.isSymbol(1)).toBe(false)


### PR DESCRIPTION
**Changes made :**
- adds isSymbol method
- adds a test case for isSymbol method

**Code explanation :**
`typeof input === 'symbol'` covers 99% of cases, and `typeof input === 'object' && Object.prototype.toString.call(input) === '[object Symbol]'` is here for cases where the code has been transpiled to an ES version < 6 (when symbols was introduced) or when (for whatever reason) a wrapper object is used (using `Object(Symbol('Supercharge')` for example ; same result as using `new String()`, but Symbol doesn't have `new`). 